### PR TITLE
Quick tweaks to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,8 @@ the maven site plugin.
 Why use Gradle-Fury
 -------------------
 
-Great question, with a sea of many maven publisher helpers (this along should raise a red flag that
-something is wrong) what stands gradle-fury apart?
-
-Check out [the wiki](https://github.com/gradle-fury/gradle-fury/wiki) for the most update to date set
-of features. It's always growing and it's easier to update the wiki.
-
-
-This notice will be removed/updated once the remaining versions are fixed
+Great question, with a sea of many maven publisher helpers (this alone should raise a red flag that
+something is wrong) what stands gradle-fury apart? Check out our [Why would you want to use Gradle Fury? wiki page](https://github.com/gradle-fury/gradle-fury/wiki) for the most update to date set of features which is always growing.
 
 Build Status
 ------------
@@ -455,7 +449,7 @@ Then execute with `gradelw build -Pprofile=ci`
 
 ## Maven Site Plugin
 
-### [Here's what it looks like][http://gradle-fury.github.io/gradle-fury]
+### [Here's what it looks like](http://gradle-fury.github.io/gradle-fury)
 
 Well it's not exactly the Maven Site Plugin, but it's our version of it. It's pretty darn close.
 It uses theming inspired by [Apache Fluido](http://maven.apache.org/skins/maven-fluido-skin/) and is loosely based


### PR DESCRIPTION
* Updated wording for **Why use Gradle-Fury** as when originally reading, I did not realize the Wiki statement related.
* Removed temporary warning. Maybe this should be moved to the version compatibility section?
* Fixed broken markdown for the Maven Site Plugin URL.

Additionally, I would recommend changing the GitHub Description for https://github.com/chrisdoyle/gradle-fury with "We have moved to https://github.com/gradle-fury/gradle-fury/" as some users may not scroll all the way down to the README, and this will catch their attention sooner. (Especially since this project is not seen as a fork.)

Lastly, next time you migrate to a new repository, I would consider using [GitHub's Transfer](https://help.github.com/articles/transferring-a-repository-owned-by-your-personal-account/) function.